### PR TITLE
Enhance custom timers with summary and color controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,29 @@ const COLOR = {
   slate700: "#334155",
 };
 
+const TIMER_COLORS = [
+  "#f97316",
+  "#3b82f6",
+  "#a855f7",
+  "#22c55e",
+  "#f43f5e",
+  "#14b8a6",
+  "#facc15",
+  "#ec4899",
+];
+
+function defaultTimerColor(index: number) {
+  if (index < 0) return TIMER_COLORS[0];
+  return TIMER_COLORS[index % TIMER_COLORS.length];
+}
+
+function sanitizeTimerColor(color: string | undefined, index: number) {
+  if (!color) return defaultTimerColor(index);
+  const hex = color.trim();
+  const valid = /^#([0-9a-f]{6}|[0-9a-f]{3})$/i.test(hex);
+  return valid ? hex : defaultTimerColor(index);
+}
+
 const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
 const now = () => Date.now();
 
@@ -664,22 +687,67 @@ function ResourceCard({
 }
 
 interface AddTimerFormProps {
-  onAdd: (label: string, duration: string) => void;
+  onAdd: (label: string, duration: string, color: string) => void;
+  defaultColor: string;
 }
 
-function AddTimerForm({ onAdd }: AddTimerFormProps) {
+function AddTimerForm({ onAdd, defaultColor }: AddTimerFormProps) {
   const [label, setLabel] = useState("");
   const [dur, setDur] = useState("");
+  const [color, setColor] = useState(defaultColor);
   const place = "mm:ss, 10m, 2h, or seconds";
+
+  useEffect(() => {
+    setColor(defaultColor);
+  }, [defaultColor]);
+
   return (
-    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
       <Input placeholder="Label (optional)" value={label} onChange={setLabel} />
       <Input placeholder={place} value={dur} onChange={setDur} />
+      <label
+        style={{
+          width: 48,
+          height: 40,
+          borderRadius: 12,
+          border: `1px solid ${COLOR.border}`,
+          background: COLOR.bg,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+          position: "relative",
+        }}
+        title="Pick timer color"
+      >
+        <span
+          style={{
+            width: 20,
+            height: 20,
+            borderRadius: "50%",
+            background: color,
+            border: `1px solid ${COLOR.border}`,
+            boxShadow: "0 0 6px rgba(0,0,0,0.45)",
+          }}
+        />
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          style={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0,
+            cursor: "pointer",
+          }}
+        />
+      </label>
       <SmallBtn
         onClick={() => {
-          onAdd(label, dur);
+          onAdd(label, dur, color);
           setLabel("");
           setDur("");
+          setColor(defaultColor);
         }}
       >
         Add
@@ -719,31 +787,124 @@ interface TimerData {
   isPaused?: boolean;
   pausedRemaining?: number | null;
   created?: number;
+  color?: string;
+  durationMs?: number;
   remainingMs?: number;
+}
+
+interface TimerDisplayData extends TimerData {
+  remainingMs: number;
+  totalMs: number;
+  progress: number;
+  colorResolved: string;
+}
+
+function computeTimerRemainingMs(t: TimerData, nowMs: number) {
+  if (t.isPaused) {
+    if (Number.isFinite(t.pausedRemaining)) return Math.max(0, (t.pausedRemaining as number) || 0);
+    if (Number.isFinite(t.targetTs)) return Math.max(0, (t.targetTs as number) - nowMs);
+    return 0;
+  }
+  if (Number.isFinite(t.targetTs)) return Math.max(0, (t.targetTs as number) - nowMs);
+  return 0;
+}
+
+function computeTimerTotalMs(t: TimerData, remaining: number, nowMs: number) {
+  if (Number.isFinite(t.durationMs)) {
+    const base = Math.max(0, t.durationMs as number);
+    return Math.max(base, remaining);
+  }
+  if (Number.isFinite(t.targetTs) && Number.isFinite(t.created)) {
+    const diff = (t.targetTs as number) - (t.created as number);
+    if (Number.isFinite(diff) && diff > 0) return Math.max(diff, remaining);
+  }
+  if (t.isPaused && Number.isFinite(t.pausedRemaining)) {
+    const rem = Math.max(0, (t.pausedRemaining as number) || 0);
+    return Math.max(rem, remaining);
+  }
+  if (Number.isFinite(t.targetTs)) {
+    const diff = Math.max(0, (t.targetTs as number) - nowMs);
+    return Math.max(diff, remaining);
+  }
+  return remaining || 1;
+}
+
+function resolveTimerColor(t: TimerData, index: number) {
+  return sanitizeTimerColor(t.color, index);
 }
 
 interface TimerRowProps {
   t: TimerData;
+  meta: TimerDisplayData;
   onAddMinutes: (minutes: number) => void;
   onPause: (pause: boolean) => void;
   onReset: () => void;
   onDelete: () => void;
   onCopy: () => void;
+  onColorChange: (color: string) => void;
 }
 
-function TimerRow({ t, onAddMinutes, onPause, onReset, onDelete, onCopy }: TimerRowProps) {
-  const rem = t.isPaused
-    ? Number.isFinite(t.pausedRemaining)
-      ? (t.pausedRemaining as number)
-      : Math.max(0, (t.targetTs ?? 0) - now())
-    : Math.max(0, (t.targetTs ?? 0) - now());
+function TimerRow({ t, meta, onAddMinutes, onPause, onReset, onDelete, onCopy, onColorChange }: TimerRowProps) {
+  const remaining = meta.remainingMs;
+  const statusLabel = t.isPaused
+    ? `Paused (${formatDHMS(remaining)})`
+    : remaining <= 0
+    ? "Ready"
+    : `${formatDHMS(remaining)} (${formatMMSS(remaining)})`;
+  const colorValue = t.color ?? meta.colorResolved;
   return (
-    <div style={cardRowStyle()}>
-      <div>
-        <div style={{ fontWeight: 600 }}>{t.label || "Timer"}</div>
-        <div style={{ fontSize: 13, color: COLOR.subtle }}>Remaining</div>
-        <div style={{ fontSize: 14 }}>
-          {formatDHMS(rem)} ({formatMMSS(rem)})
+    <div style={cardRowStyle(meta.colorResolved)}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <label
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              background: colorValue,
+              border: `1px solid ${COLOR.border}`,
+              boxShadow: "0 0 6px rgba(0,0,0,0.45)",
+              cursor: "pointer",
+              position: "relative",
+              flexShrink: 0,
+            }}
+            title="Change timer color"
+          >
+            <input
+              type="color"
+              value={colorValue}
+              onChange={(e) => onColorChange(e.target.value)}
+              style={{
+                position: "absolute",
+                inset: 0,
+                opacity: 0,
+                cursor: "pointer",
+              }}
+            />
+          </label>
+          <div>
+            <div style={{ fontWeight: 600, wordBreak: "break-word" }}>{t.label || "Timer"}</div>
+            <div style={{ fontSize: 13, color: COLOR.subtle }}>Remaining</div>
+            <div style={{ fontSize: 14 }}>{statusLabel}</div>
+          </div>
+        </div>
+        <div
+          style={{
+            marginTop: 10,
+            height: 6,
+            background: COLOR.border,
+            borderRadius: 999,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              width: `${meta.progress * 100}%`,
+              background: meta.colorResolved,
+              height: "100%",
+              transition: "width 0.3s ease",
+            }}
+          />
         </div>
       </div>
       <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
@@ -764,7 +925,81 @@ function TimerRow({ t, onAddMinutes, onPause, onReset, onDelete, onCopy }: Timer
   );
 }
 
-function cardRowStyle(): React.CSSProperties {
+function TimerSummaryList({ timers }: { timers: TimerDisplayData[] }) {
+  if (!timers.length)
+    return (
+      <p style={{ color: COLOR.subtle, fontSize: 13, marginTop: 6, marginBottom: 0 }}>
+        No custom timers yet.
+      </p>
+    );
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {timers.map((t) => {
+        const label = t.label || "Timer";
+        const status = t.isPaused
+          ? `Paused (${formatDHMS(t.remainingMs)})`
+          : t.remainingMs <= 0
+          ? "Ready"
+          : `${formatDHMS(t.remainingMs)} (${formatMMSS(t.remainingMs)})`;
+        return (
+          <div
+            key={t.id}
+            style={{
+              background: COLOR.bg,
+              border: `1px solid ${COLOR.border}`,
+              borderRadius: 12,
+              padding: 10,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <span style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 600 }}>
+                <span
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: "50%",
+                    background: t.colorResolved,
+                    border: `1px solid ${COLOR.border}`,
+                    boxShadow: "0 0 4px rgba(0,0,0,0.45)",
+                  }}
+                />
+                <span style={{ wordBreak: "break-word" }}>{label}</span>
+              </span>
+              <span style={{ color: COLOR.subtle, fontSize: 12 }}>{status}</span>
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                height: 4,
+                background: COLOR.border,
+                borderRadius: 999,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${t.progress * 100}%`,
+                  background: t.colorResolved,
+                  height: "100%",
+                  transition: "width 0.3s ease",
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function cardRowStyle(accent?: string): React.CSSProperties {
   return {
     background: COLOR.card,
     border: `1px solid ${COLOR.border}`,
@@ -773,6 +1008,9 @@ function cardRowStyle(): React.CSSProperties {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
+    gap: 12,
+    borderLeft: accent ? `4px solid ${accent}` : undefined,
+    paddingLeft: accent ? 16 : 12,
   };
 }
 
@@ -984,19 +1222,71 @@ export default function UmaResourceTracker() {
   }, []);
 
   useEffect(() => {
+    const nowMs = now();
     setTimers((prev) =>
-      prev.map((t) => {
-        if (t && t.targetTs) return t;
-        const rem = Number.isFinite(t?.remainingMs) ? t?.remainingMs || 0 : 0;
-        return {
+      prev.map((t, index) => {
+        if (!t)
+          return {
+            id: crypto.randomUUID(),
+            label: "Timer",
+            targetTs: nowMs,
+            isPaused: false,
+            pausedRemaining: null,
+            created: nowMs,
+            color: defaultTimerColor(index),
+            durationMs: 0,
+          };
+        const rem = Number.isFinite(t.remainingMs) ? (t.remainingMs as number) : 0;
+        const hasTarget = Number.isFinite(t.targetTs);
+        const created = Number.isFinite(t.created) ? (t.created as number) : nowMs;
+        const candidate: TimerData = {
           ...t,
-          targetTs: now() + rem,
-          pausedRemaining: t?.isPaused ? rem : null,
+          targetTs: hasTarget ? (t.targetTs as number) : nowMs + rem,
+          pausedRemaining: t.isPaused ? (Number.isFinite(t.pausedRemaining) ? t.pausedRemaining : rem) : null,
+          created,
+        };
+        const remaining = computeTimerRemainingMs(candidate, nowMs);
+        const duration = Number.isFinite(t.durationMs)
+          ? Math.max(0, t.durationMs as number)
+          : computeTimerTotalMs(candidate, remaining, nowMs);
+        return {
+          ...candidate,
+          color: sanitizeTimerColor(candidate.color, index),
+          durationMs: duration,
         };
       })
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const decoratedTimers = useMemo(() => {
+    const nowMs = now();
+    return timers.map((t, index) => {
+      const remaining = computeTimerRemainingMs(t, nowMs);
+      const total = computeTimerTotalMs(t, remaining, nowMs);
+      const colorResolved = resolveTimerColor(t, index);
+      const progress = total > 0 ? clamp(1 - remaining / total, 0, 1) : 1;
+      return { ...t, remainingMs: remaining, totalMs: total, progress, colorResolved } as TimerDisplayData;
+    });
+  }, [timers, tick]);
+
+  const timerSummary = useMemo(() => {
+    const arr = [...decoratedTimers];
+    arr.sort((a, b) => {
+      const weight = (x: TimerDisplayData) => {
+        if (!x.isPaused && x.remainingMs > 0) return 0;
+        if (x.isPaused && x.remainingMs > 0) return 1;
+        return 2;
+      };
+      const wa = weight(a);
+      const wb = weight(b);
+      if (wa !== wb) return wa - wb;
+      return a.remainingMs - b.remainingMs;
+    });
+    return arr;
+  }, [decoratedTimers]);
+
+  const nextTimerColor = useMemo(() => defaultTimerColor(timers.length), [timers.length]);
 
   const curTP = useMemo(
     () => computeCurrent(tp.base, tp.last, TP_RATE_MS, TP_CAP, tp.nextOverride, now()),
@@ -1081,36 +1371,46 @@ export default function UmaResourceTracker() {
     if (kind === "tp") setTP((prev) => ({ ...prev, nextOverride: target }));
     else setRP((prev) => ({ ...prev, nextOverride: target }));
   }
-  function addTimer(label: string, input: string) {
+  function addTimer(label: string, input: string, colorInput: string) {
     const ms = parseFlexible(input);
     if (ms == null) return;
-    const t: TimerData = {
-      id: crypto.randomUUID(),
-      label,
-      targetTs: now() + ms,
-      isPaused: false,
-      pausedRemaining: null,
-      created: now(),
-    };
-    setTimers((prev) => [...prev, t]);
+    const nowMs = now();
+    setTimers((prev) => {
+      const color = sanitizeTimerColor(colorInput, prev.length);
+      const t: TimerData = {
+        id: crypto.randomUUID(),
+        label,
+        targetTs: nowMs + ms,
+        isPaused: false,
+        pausedRemaining: null,
+        created: nowMs,
+        color,
+        durationMs: ms,
+      };
+      return [...prev, t];
+    });
   }
   function pauseTimer(id: string, pause: boolean) {
+    const nowMs = now();
     setTimers((prev) =>
       prev.map((t) => {
         if (t.id !== id) return t;
         if (pause && !t.isPaused) {
+          const remaining = Number.isFinite(t.targetTs) ? Math.max(0, (t.targetTs as number) - nowMs) : 0;
           return {
             ...t,
             isPaused: true,
-            pausedRemaining: Math.max(0, (t.targetTs ?? now()) - now()),
+            pausedRemaining: remaining,
           };
         }
         if (!pause && t.isPaused) {
-          const rem = Number.isFinite(t.pausedRemaining) ? t.pausedRemaining || 0 : 0;
+          const rem = Number.isFinite(t.pausedRemaining)
+            ? Math.max(0, (t.pausedRemaining as number) || 0)
+            : Math.max(0, (t.targetTs ?? nowMs) - nowMs);
           return {
             ...t,
             isPaused: false,
-            targetTs: now() + rem,
+            targetTs: nowMs + rem,
             pausedRemaining: null,
           };
         }
@@ -1120,21 +1420,53 @@ export default function UmaResourceTracker() {
   }
   function addMinutes(id: string, mins: number) {
     const delta = mins * 60000;
+    const nowMs = now();
     setTimers((prev) =>
-      prev.map((t) => {
+      prev.map((t, index) => {
         if (t.id !== id) return t;
+        const baseDuration = Number.isFinite(t.durationMs)
+          ? Math.max(0, t.durationMs as number)
+          : computeTimerTotalMs(t, computeTimerRemainingMs(t, nowMs), nowMs);
         if (t.isPaused) {
           const rem = Number.isFinite(t.pausedRemaining)
-            ? t.pausedRemaining || Math.max(0, (t.targetTs ?? now()) - now())
-            : Math.max(0, (t.targetTs ?? now()) - now());
-          return { ...t, pausedRemaining: rem + delta };
+            ? Math.max(0, (t.pausedRemaining as number) || 0)
+            : Math.max(0, (t.targetTs ?? nowMs) - nowMs);
+          return {
+            ...t,
+            pausedRemaining: rem + delta,
+            durationMs: Math.max(0, baseDuration + delta),
+            color: sanitizeTimerColor(t.color, index),
+          };
         }
-        return { ...t, targetTs: (t.targetTs ?? now()) + delta };
+        const targetBase = Number.isFinite(t.targetTs) ? (t.targetTs as number) : nowMs;
+        return {
+          ...t,
+          targetTs: targetBase + delta,
+          durationMs: Math.max(0, baseDuration + delta),
+          color: sanitizeTimerColor(t.color, index),
+        };
       })
     );
   }
   function resetTimer(id: string) {
-    setTimers((prev) => prev.map((t) => (t.id === id ? { ...t, isPaused: true, pausedRemaining: 0 } : t)));
+    setTimers((prev) =>
+      prev.map((t, index) =>
+        t.id === id
+          ? {
+              ...t,
+              isPaused: true,
+              pausedRemaining: 0,
+              durationMs: Number.isFinite(t.durationMs) ? Math.max(0, t.durationMs as number) : 0,
+              color: sanitizeTimerColor(t.color, index),
+            }
+          : t
+      )
+    );
+  }
+  function changeTimerColor(id: string, colorInput: string) {
+    setTimers((prev) =>
+      prev.map((t, index) => (t.id === id ? { ...t, color: sanitizeTimerColor(colorInput, index) } : t))
+    );
   }
   function deleteTimer(id: string) {
     setTimers((prev) => prev.filter((t) => t.id !== id));
@@ -1191,8 +1523,12 @@ export default function UmaResourceTracker() {
     <div style={{ maxWidth: 1100, margin: "0 auto", padding: 16 }}>
       <Header hud={hud} />
 
-      <Card title="Daily Reset (10:00 AM Central)">
+      <Card title="Daily Reset & Custom Timers">
         <CountdownRow targetMs={nextReset} />
+        <div style={{ marginTop: 12 }}>
+          <div style={{ fontSize: 13, color: COLOR.subtle, marginBottom: 6 }}>Custom timers</div>
+          <TimerSummaryList timers={timerSummary} />
+        </div>
         <RowRight>
           <SmallBtn onClick={() => copyOverlayURL("reset")}>Copy Overlay URL</SmallBtn>
         </RowRight>
@@ -1300,20 +1636,22 @@ export default function UmaResourceTracker() {
       </div>
 
       <Card title="Custom Flexible Timers">
-        <AddTimerForm onAdd={addTimer} />
+        <AddTimerForm onAdd={addTimer} defaultColor={nextTimerColor} />
         <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: 12 }}>
-          {timers.length === 0 ? (
+          {decoratedTimers.length === 0 ? (
             <p style={{ color: COLOR.subtle, fontSize: 14 }}>No custom timers yet.</p>
           ) : (
-            timers.map((t) => (
+            decoratedTimers.map((meta) => (
               <TimerRow
-                key={t.id}
-                t={t}
-                onAddMinutes={(m) => addMinutes(t.id, m)}
-                onPause={(p) => pauseTimer(t.id, p)}
-                onReset={() => resetTimer(t.id)}
-                onDelete={() => deleteTimer(t.id)}
-                onCopy={() => copyOverlayURL("timer", t.id)}
+                key={meta.id}
+                t={meta}
+                meta={meta}
+                onAddMinutes={(m) => addMinutes(meta.id, m)}
+                onPause={(p) => pauseTimer(meta.id, p)}
+                onReset={() => resetTimer(meta.id)}
+                onDelete={() => deleteTimer(meta.id)}
+                onCopy={() => copyOverlayURL("timer", meta.id)}
+                onColorChange={(color) => changeTimerColor(meta.id, color)}
               />
             ))
           )}


### PR DESCRIPTION
## Summary
- combine the daily reset card with a custom timer summary that shows countdown progress bars
- add color selection to flexible timers, render progress bars, and surface timer metadata in each card
- normalize stored timer data to support colors and countdown tracking for legacy entries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbab016108832aa86a8b54657e3dff