### PR TITLE
Add configurable timezone settings menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,19 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-const TZ = "America/Chicago";
+const DEFAULT_TZ = "America/Chicago";
+
+function isValidTimeZone(value: string) {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureTimeZone(value: string) {
+  return isValidTimeZone(value) ? value : DEFAULT_TZ;
+}
 const COLOR = {
   bg: "#0b1220",
   card: "#121a2a",
@@ -103,9 +116,10 @@ export function parseFlexible(input: unknown) {
 }
 
 function getTZOffsetDesignator(timeZone: string) {
+  const zone = ensureTimeZone(timeZone);
   try {
     const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
+      timeZone: zone,
       timeZoneName: "shortOffset",
     }).formatToParts(new Date());
     let off =
@@ -125,10 +139,11 @@ function getTZOffsetDesignator(timeZone: string) {
   return "-05:00";
 }
 
-export function nextDailyResetTS(base = new Date()) {
+export function nextDailyResetTS(base = new Date(), timeZone = DEFAULT_TZ) {
   const d = new Date(base);
+  const zone = ensureTimeZone(timeZone);
   const locale = new Intl.DateTimeFormat("en-US", {
-    timeZone: TZ,
+    timeZone: zone,
     hour12: false,
     year: "numeric",
     month: "2-digit",
@@ -138,7 +153,7 @@ export function nextDailyResetTS(base = new Date()) {
   const yyyy = parts.year;
   const mm = parts.month;
   const dd = parts.day;
-  const tzOff = getTZOffsetDesignator(TZ);
+  const tzOff = getTZOffsetDesignator(zone);
   let targetMs = new Date(`${yyyy}-${mm}-${dd}T10:00:00${tzOff}`).getTime();
   if (!Number.isFinite(targetMs)) {
     targetMs = new Date(`${yyyy}-${mm}-${dd}T10:00:00`).getTime() || Date.now();
@@ -310,17 +325,56 @@ function useQuery() {
 
 interface HeaderProps {
   hud: boolean;
+  onOpenSettings: () => void;
+  timeZone: string;
+  isSettingsOpen: boolean;
 }
 
-function Header({ hud }: HeaderProps) {
+function Header({ hud, onOpenSettings, timeZone, isSettingsOpen }: HeaderProps) {
+  const zone = ensureTimeZone(timeZone);
   return (
-    <div style={{ marginBottom: 12 }}>
-      <div style={{ fontSize: hud ? 20 : 24, fontWeight: 700 }}>
-        Uma RP/TP Tracker — Streamer Build2
+    <div
+      style={{
+        marginBottom: 12,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: 12,
+        flexWrap: "wrap",
+      }}
+    >
+      <div>
+        <div style={{ fontSize: hud ? 20 : 24, fontWeight: 700 }}>
+          Uma RP/TP Tracker — Streamer Build2
+        </div>
+        <div style={{ color: COLOR.subtle, fontSize: 12 }}>
+          Dark theme • TP gold • RP blue • HUD mode & overlay URLs
+        </div>
+        <div style={{ color: COLOR.subtle, fontSize: 12, marginTop: 4 }}>
+          Current time zone: {zone}
+        </div>
       </div>
-      <div style={{ color: COLOR.subtle, fontSize: 12 }}>
-        Dark theme • TP gold • RP blue • HUD mode & overlay URLs
-      </div>
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "8px 12px",
+          borderRadius: 999,
+          background: isSettingsOpen ? COLOR.border : COLOR.slate700,
+          color: COLOR.text,
+          border: `1px solid ${COLOR.border}`,
+          fontSize: 13,
+          cursor: "pointer",
+        }}
+        title="Open settings"
+        aria-expanded={isSettingsOpen}
+      >
+        <span aria-hidden="true">⚙️</span>
+        <span>Settings</span>
+      </button>
     </div>
   );
 }
@@ -462,13 +516,14 @@ function Input({ value, onChange, placeholder, type = "text" }: InputProps) {
   );
 }
 
-function CountdownRow({ targetMs }: { targetMs: number }) {
+function CountdownRow({ targetMs, timeZone }: { targetMs: number; timeZone: string }) {
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = window.setInterval(() => setTick((t) => t + 1), 1000);
     return () => window.clearInterval(id);
   }, []);
   const rem = Math.max(0, targetMs - now());
+  const zone = ensureTimeZone(timeZone);
   return (
     <div
       style={{
@@ -480,7 +535,7 @@ function CountdownRow({ targetMs }: { targetMs: number }) {
       }}
     >
       <div style={{ fontSize: 13, color: COLOR.subtle }}>
-        Absolute: {new Date(targetMs).toLocaleString(undefined, { timeZone: TZ })}
+        Absolute: {new Date(targetMs).toLocaleString(undefined, { timeZone: zone })}
       </div>
       <div style={{ fontSize: 14 }}>
         Time left: {formatDHMS(rem)} ({formatMMSS(rem)})
@@ -507,6 +562,7 @@ interface ResourceCardProps {
   onSetNextOverride: (value: string) => void;
   hud: boolean;
   onCopyOverlay: () => void;
+  timeZone: string;
 }
 
 function ResourceCard({
@@ -527,11 +583,13 @@ function ResourceCard({
   onSetNextOverride,
   hud,
   onCopyOverlay,
+  timeZone,
 }: ResourceCardProps) {
   const [nextInput, setNextInput] = useState("");
   const [amountInput, setAmountInput] = useState("");
   const timeToNext = current.nextPoint - now();
   const place = "mm:ss, 10m, 2h, or seconds";
+  const zone = ensureTimeZone(timeZone);
 
   const bigValStyle: React.CSSProperties = {
     fontWeight: 800,
@@ -585,7 +643,7 @@ function ResourceCard({
             Next +1 in: {formatDHMS(timeToNext)} ({formatMMSS(timeToNext)})
           </div>
           <div style={{ fontSize: 13, marginTop: 2 }}>
-            Full at: {new Date(current.fullAt).toLocaleString(undefined, { timeZone: TZ })} • Time to full:
+            Full at: {new Date(current.fullAt).toLocaleString(undefined, { timeZone: zone })} • Time to full:
             {" "}
             {formatDHMS(fullInfo.ms)} ({formatMMSS(fullInfo.ms)})
           </div>
@@ -609,7 +667,7 @@ function ResourceCard({
                         <span style={{ color: COLOR.good }}>Ready ✓</span>
                       ) : (
                         <span style={{ color: COLOR.subtle }}>
-                          {new Date(t).toLocaleTimeString([], { timeZone: TZ })}
+                          {new Date(t).toLocaleTimeString([], { timeZone: zone })}
                         </span>
                       )}
                     </li>
@@ -791,9 +849,10 @@ interface OverlayViewProps {
   nextReset: number;
   timers: TimerData[];
   absTimers: AbsTimer[];
+  timeZone: string;
 }
 
-function OverlayView({ overlay, curTP, curRP, tpFull, rpFull, nextReset, timers, absTimers }: OverlayViewProps) {
+function OverlayView({ overlay, curTP, curRP, tpFull, rpFull, nextReset, timers, absTimers, timeZone }: OverlayViewProps) {
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = window.setInterval(() => setTick((t) => t + 1), 1000);
@@ -805,6 +864,7 @@ function OverlayView({ overlay, curTP, curRP, tpFull, rpFull, nextReset, timers,
   };
   const slab: React.CSSProperties = { fontSize: 64, fontWeight: 900, letterSpacing: 1 };
   const sub: React.CSSProperties = { fontSize: 16, color: COLOR.subtle };
+  const zone = ensureTimeZone(timeZone);
 
   if (overlay === "tp")
     return (
@@ -828,7 +888,7 @@ function OverlayView({ overlay, curTP, curRP, tpFull, rpFull, nextReset, timers,
     return (
       <div style={{ ...styleTxt }}>
         <div style={{ ...slab }}>Daily Reset</div>
-        <div style={sub}>{new Date(nextReset).toLocaleString(undefined, { timeZone: TZ })}</div>
+        <div style={sub}>{new Date(nextReset).toLocaleString(undefined, { timeZone: zone })}</div>
         <div style={{ fontSize: 32, marginTop: 8 }}>{formatDHMS(nextReset - now())}</div>
       </div>
     );
@@ -858,7 +918,7 @@ function OverlayView({ overlay, curTP, curRP, tpFull, rpFull, nextReset, timers,
     return (
       <div style={{ ...styleTxt }}>
         <div style={{ ...slab }}>{a.label || "Timer"}</div>
-        <div style={sub}>{new Date(a.ts).toLocaleString(undefined, { timeZone: TZ })}</div>
+        <div style={sub}>{new Date(a.ts).toLocaleString(undefined, { timeZone: zone })}</div>
         <div style={{ fontSize: 32 }}>
           {formatDHMS(rem)} ({formatMMSS(rem)})
         </div>
@@ -949,6 +1009,20 @@ export default function UmaResourceTracker() {
     rp: {},
     timers: {},
   });
+  const [timezone, setTimezone] = useLocalStorage<string>("uma.timezone", DEFAULT_TZ);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [tzDraft, setTzDraft] = useState(timezone);
+  const [tzError, setTzError] = useState<string | null>(null);
+
+  const activeTimeZone = ensureTimeZone(timezone);
+
+  useEffect(() => {
+    if (!isValidTimeZone(timezone)) setTimezone(DEFAULT_TZ);
+  }, [timezone, setTimezone]);
+
+  useEffect(() => {
+    if (!settingsOpen) setTzDraft(timezone);
+  }, [timezone, settingsOpen]);
 
   useEffect(() => {
     const sTP = sanitizeResource(tpRaw, TP_CAP);
@@ -1006,7 +1080,11 @@ export default function UmaResourceTracker() {
     () => computeCurrent(rp.base, rp.last, RP_RATE_MS, RP_CAP, rp.nextOverride, now()),
     [rp, tick]
   );
-  const nextReset = useMemo(() => nextDailyResetTS(new Date()), [tick]);
+  const nextReset = useMemo(
+    () => nextDailyResetTS(new Date(), activeTimeZone),
+    [tick, activeTimeZone]
+  );
+  const tzOffset = useMemo(() => getTZOffsetDesignator(activeTimeZone), [activeTimeZone]);
 
   const [anchoredInit, setAnchoredInit] = useState(false);
   useEffect(() => {
@@ -1057,6 +1135,35 @@ export default function UmaResourceTracker() {
   );
   const rpFull = useMemo(() => timeToFull(curRP, RP_RATE_MS, RP_CAP), [curRP]);
   const tpFull = useMemo(() => timeToFull(curTP, TP_RATE_MS, TP_CAP), [curTP]);
+
+  function toggleSettings() {
+    setSettingsOpen((prev) => {
+      const next = !prev;
+      setTzDraft(timezone);
+      setTzError(null);
+      return next;
+    });
+  }
+
+  function saveTimeZone() {
+    const trimmed = tzDraft.trim();
+    if (!trimmed) {
+      setTzError("Time zone cannot be empty.");
+      return;
+    }
+    if (!isValidTimeZone(trimmed)) {
+      setTzError("Enter a valid IANA time zone (e.g., America/Chicago).");
+      return;
+    }
+    setTimezone(trimmed);
+    setTzError(null);
+  }
+
+  function closeSettings() {
+    setSettingsOpen(false);
+    setTzError(null);
+    setTzDraft(timezone);
+  }
 
   function adjustTP(delta: number) {
     const current = computeCurrent(tp.base, tp.last, TP_RATE_MS, TP_CAP, tp.nextOverride, now());
@@ -1170,6 +1277,13 @@ export default function UmaResourceTracker() {
     document.body.style.color = COLOR.text;
   }, []);
 
+  const tzDraftTrimmed = tzDraft.trim();
+  const tzDraftIsValid = tzDraftTrimmed.length > 0 && isValidTimeZone(tzDraftTrimmed);
+  const tzPreview = settingsOpen && tzDraftIsValid
+    ? new Date().toLocaleString(undefined, { timeZone: tzDraftTrimmed })
+    : null;
+  const resetTitle = `Daily Reset (10:00 AM ${activeTimeZone} • UTC${tzOffset})`;
+
   if (overlay) {
     return (
       <div style={{ padding: 16, fontFamily: "Inter, ui-sans-serif, system-ui", color: COLOR.text }}>
@@ -1182,6 +1296,7 @@ export default function UmaResourceTracker() {
           nextReset={nextReset}
           timers={timers}
           absTimers={absTimers}
+          timeZone={activeTimeZone}
         />
       </div>
     );
@@ -1189,10 +1304,55 @@ export default function UmaResourceTracker() {
 
   return (
     <div style={{ maxWidth: 1100, margin: "0 auto", padding: 16 }}>
-      <Header hud={hud} />
+      <Header
+        hud={hud}
+        onOpenSettings={toggleSettings}
+        timeZone={activeTimeZone}
+        isSettingsOpen={settingsOpen}
+      />
 
-      <Card title="Daily Reset (10:00 AM Central)">
-        <CountdownRow targetMs={nextReset} />
+      {settingsOpen && (
+        <Card title="Settings">
+          <div style={{ display: "grid", gap: 12 }}>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>Time zone</div>
+              <div style={{ fontSize: 12, color: COLOR.subtle, marginTop: 4 }}>
+                Determines when the 10:00 AM daily reset occurs and how timers are displayed.
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+              <div style={{ flex: 1, minWidth: 220 }}>
+                <Input
+                  value={tzDraft}
+                  onChange={(v) => {
+                    setTzDraft(v);
+                    setTzError(null);
+                  }}
+                  placeholder="America/Chicago"
+                />
+              </div>
+              <SmallBtn onClick={saveTimeZone}>Save time zone</SmallBtn>
+              <SmallBtn onClick={closeSettings}>Done</SmallBtn>
+            </div>
+            {tzError && (
+              <div style={{ fontSize: 12, color: COLOR.danger }}>{tzError}</div>
+            )}
+            {!tzError && tzDraftTrimmed.length > 0 && !tzDraftIsValid && (
+              <div style={{ fontSize: 12, color: COLOR.subtle }}>
+                Enter a valid IANA time zone such as America/Chicago or Asia/Tokyo.
+              </div>
+            )}
+            {tzPreview && (
+              <div style={{ fontSize: 12, color: COLOR.subtle }}>
+                Current local time in {tzDraftTrimmed}: {tzPreview}
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
+
+      <Card title={resetTitle}>
+        <CountdownRow targetMs={nextReset} timeZone={activeTimeZone} />
         <RowRight>
           <SmallBtn onClick={() => copyOverlayURL("reset")}>Copy Overlay URL</SmallBtn>
         </RowRight>
@@ -1276,6 +1436,7 @@ export default function UmaResourceTracker() {
           onSetNextOverride={(v) => setNextPointOverride("tp", v)}
           hud={hud}
           onCopyOverlay={() => copyOverlayURL("tp")}
+          timeZone={activeTimeZone}
         />
 
         <ResourceCard
@@ -1296,6 +1457,7 @@ export default function UmaResourceTracker() {
           onSetNextOverride={(v) => setNextPointOverride("rp", v)}
           hud={hud}
           onCopyOverlay={() => copyOverlayURL("rp")}
+          timeZone={activeTimeZone}
         />
       </div>
 
@@ -1333,7 +1495,7 @@ export default function UmaResourceTracker() {
                   <div>
                     <div style={{ fontWeight: 600 }}>{a.label || "Timer"}</div>
                     <div style={{ fontSize: 13, color: COLOR.subtle }}>
-                      At: {new Date(a.ts).toLocaleString(undefined, { timeZone: TZ })}
+                      At: {new Date(a.ts).toLocaleString(undefined, { timeZone: activeTimeZone })}
                     </div>
                     <div style={{ fontSize: 14 }}>
                       Time left: {formatDHMS(rem)} ({formatMMSS(rem)})
@@ -1377,7 +1539,7 @@ export default function UmaResourceTracker() {
 
     const off = (function () {
       try {
-        return getTZOffsetDesignator("America/Chicago");
+        return getTZOffsetDesignator(DEFAULT_TZ);
       } catch (e) {
         console.warn(e);
         return "";
@@ -1403,7 +1565,7 @@ export default function UmaResourceTracker() {
     const a2 = computeCurrent(45, nowMs, 10 * 60 * 1000, 100, anchor, nowMs);
     eq(Math.abs(a1.nextPoint - a2.nextPoint) < 5, true, "anchor keeps nextPoint stable across spends");
 
-    const ndr = nextDailyResetTS(new Date());
+    const ndr = nextDailyResetTS(new Date(), DEFAULT_TZ);
     eq(Number.isFinite(ndr) && ndr > Date.now(), true, "nextDailyResetTS returns a future finite timestamp");
   } catch (e) {
     console.warn("Test harness error: ", e);


### PR DESCRIPTION
## Summary
- add timezone validation helpers and persist a configurable time zone in local storage
- introduce a settings panel with a gear button and preview to update the tracker time zone
- update countdowns, resource cards, overlays, and timers to respect the chosen time zone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbab2644fc832aae03a72349e80251