### PR TITLE
Adjust timer overview colors by label keywords

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,12 @@ const TIMER_COLORS = [
   "#ec4899",
 ];
 
+const TIMER_CATEGORY_COLORS = {
+  purple: "#a855f7",
+  gray: "#9ca3af",
+  forest: "#228b22",
+} as const;
+
 function defaultTimerColor(index: number) {
   if (index < 0) return TIMER_COLORS[0];
   return TIMER_COLORS[index % TIMER_COLORS.length];
@@ -891,6 +897,14 @@ function resolveTimerColor(t: TimerData, index: number) {
   return sanitizeTimerColor(t.color, index);
 }
 
+function resolveOverviewTimerColor(label?: string) {
+  const name = label?.trim();
+  if (!name) return TIMER_CATEGORY_COLORS.forest;
+  if (/\b(champion|cup|cc)\b/i.test(name)) return TIMER_CATEGORY_COLORS.purple;
+  if (/\b(support|card)\b/i.test(name)) return TIMER_CATEGORY_COLORS.gray;
+  return TIMER_CATEGORY_COLORS.forest;
+}
+
 interface TimerRowProps {
   t: TimerData;
   meta: TimerDisplayData;
@@ -1013,6 +1027,7 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
               : t.remainingMs <= 0
               ? "Ready"
               : `${formatDHMS(t.remainingMs)} (${formatMMSS(t.remainingMs)})`;
+            const overviewColor = resolveOverviewTimerColor(label);
             return (
               <div
                 key={t.id}
@@ -1037,12 +1052,12 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
                         width: 10,
                         height: 10,
                         borderRadius: "50%",
-                        background: t.colorResolved,
+                        background: overviewColor,
                         border: `1px solid ${COLOR.border}`,
                         boxShadow: "0 0 4px rgba(0,0,0,0.45)",
                       }}
                     />
-                    <span style={{ wordBreak: "break-word" }}>{label}</span>
+                    <span style={{ wordBreak: "break-word", color: overviewColor }}>{label}</span>
                   </span>
                   <span style={{ color: COLOR.subtle, fontSize: 12 }}>{status}</span>
                 </div>
@@ -1058,7 +1073,7 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
                   <div
                     style={{
                       width: `${t.progress * 100}%`,
-                      background: t.colorResolved,
+                      background: overviewColor,
                       height: "100%",
                       transition: "width 0.3s ease",
                     }}
@@ -1075,6 +1090,8 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
           <div style={{ fontSize: 13, color: COLOR.subtle }}>Exact date/time timers</div>
           {sortedAbs.map((a) => {
             const rem = Math.max(0, a.ts - nowMs);
+            const label = a.label || "Timer";
+            const overviewColor = resolveOverviewTimerColor(label);
             return (
               <div
                 key={a.id}
@@ -1093,8 +1110,8 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
                     gap: 8,
                   }}
                 >
-                  <span style={{ fontWeight: 600, wordBreak: "break-word" }}>
-                    {a.label || "Timer"}
+                  <span style={{ fontWeight: 600, wordBreak: "break-word", color: overviewColor }}>
+                    {label}
                   </span>
                   <span style={{ color: COLOR.subtle, fontSize: 12 }}>
                     {new Date(a.ts).toLocaleString(undefined, { timeZone: zone })}


### PR DESCRIPTION
## Summary
- add timer category color constants and helper for daily reset overview timers
- color flexible and absolute timers purple, gray, or forest green based on label keywords

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbb751b350832a9560205da0ce93b2