### PR TITLE
Restore TP and RP theme colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,10 @@ const COLOR = {
   border: "#1f2f4d",
   text: "#f8fbff",
   subtle: "#cdd9f5",
-  tp: "#38bdf8",
-  rp: "#818cf8",
+  // Keep TP gold to match the in-game resource card styling.
+  tp: "#facc15",
+  // Keep RP blue to match the in-game resource card styling.
+  rp: "#38bdf8",
   good: "#22c55e",
   danger: "#f87171",
   slate700: "#2c3a57",


### PR DESCRIPTION
## Summary
- restore the TP overlay/card accent to its gold hue and the RP accent to blue so they match the game palette
- add comments explaining that these specific colors are intentional and should not be changed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdead7640832a86cf797cac5407d2