### PR TITLE
Update header copy for release candidate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,10 +603,7 @@ function Header({
     >
       <div>
         <div style={{ fontSize: hud ? 20 : 24, fontWeight: 700 }}>
-          Uma RP/TP Tracker — Streamer Build2
-        </div>
-        <div style={{ color: COLOR.subtle, fontSize: 12 }}>
-          Dark theme • TP gold • RP blue • HUD mode & overlay URLs
+          Uma RP/TP Tracker — Release Candidate
         </div>
         <div style={{ color: COLOR.subtle, fontSize: 12, marginTop: 4 }}>
           Current time zone: {zone}


### PR DESCRIPTION
## Summary
- retitle the header to "Uma RP/TP Tracker — Release Candidate"
- drop the obsolete dark theme descriptor line so the banner reads like a release candidate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff74409f4832abe4353e974d02623