### PR TITLE
Add 30-day countdown bars to absolute timers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ const TIMER_COLORS = [
 ];
 
 const HOTKEY_THROTTLE_MS = 150;
+const ABS_TIMER_COUNTDOWN_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 type HotkeyActionId = "tpSpend30" | "tpSpend1" | "rpSpend1" | "rpSpend5";
 
@@ -276,6 +277,13 @@ function withAlpha(hex: string, alpha: number) {
   return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
 }
 const now = () => Date.now();
+
+function absTimerCountdownProgress(status: AbsTimerStatus | undefined, remainingMs: number) {
+  if (status === "completed" || status === "expired") return 0;
+  if (remainingMs <= 0) return 0;
+  if (remainingMs >= ABS_TIMER_COUNTDOWN_WINDOW_MS) return 1;
+  return remainingMs / ABS_TIMER_COUNTDOWN_WINDOW_MS;
+}
 
 export function formatDHMS(ms: number) {
   if (!Number.isFinite(ms)) ms = 0;
@@ -1526,6 +1534,9 @@ function AbsTimerItem({
     remaining > 0
       ? `Time left: ${formatDHMS(remaining)} (${formatMMSS(remaining)})`
       : `Ended ${formatDHMS(-remaining)} ago`;
+  const countdownProgress = absTimerCountdownProgress(timer.status, remaining);
+  const countdownTrack = withAlpha(mixColor(accent, COLOR.bg, 0.65), 0.5);
+  const countdownFill = mixColor(accent, "#ffffff", 0.15);
   let statusText = "Active";
   let statusColor = mixColor(accent, "#ffffff", 0.2);
   if (timer.status === "completed") {
@@ -1564,6 +1575,27 @@ function AbsTimerItem({
             </div>
             <div style={{ fontSize: 14 }}>{timeLine}</div>
             <div style={{ fontSize: 13, color: statusColor }}>Status: {statusText}</div>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontSize: 11, color: COLOR.subtle }}>30-day countdown</div>
+              <div
+                style={{
+                  height: 6,
+                  background: countdownTrack,
+                  borderRadius: 999,
+                  overflow: "hidden",
+                  boxShadow: `inset 0 0 4px ${withAlpha("#000000", 0.35)}`,
+                }}
+              >
+                <div
+                  style={{
+                    width: `${countdownProgress * 100}%`,
+                    background: countdownFill,
+                    height: "100%",
+                    transition: "width 0.3s ease",
+                  }}
+                />
+              </div>
+            </div>
           </div>
         )}
       </div>
@@ -2035,6 +2067,9 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
                 rem > 0
                   ? `Time left: ${formatDHMS(rem)} (${formatMMSS(rem)})`
                   : `Ended ${formatDHMS(-rem)} ago`;
+              const countdownProgress = absTimerCountdownProgress(a.status, rem);
+              const countdownTrack = withAlpha(mixColor(accent, COLOR.bg, 0.65), 0.5);
+              const countdownFill = mixColor(accent, "#ffffff", 0.15);
               const statusText =
                 a.status === "completed"
                   ? "Completed"
@@ -2060,6 +2095,27 @@ function TimerOverviewList({ timers, absTimers, timeZone }: TimerOverviewListPro
                     </div>
                     <div style={{ fontSize: 12, color: timelineColor }}>{timeLine}</div>
                     <div style={{ fontSize: 12, color: statusColor }}>Status: {statusText}</div>
+                    <div style={{ display: "grid", gap: 4 }}>
+                      <div style={{ fontSize: 11, color: COLOR.subtle }}>30-day countdown</div>
+                      <div
+                        style={{
+                          height: 6,
+                          background: countdownTrack,
+                          borderRadius: 999,
+                          overflow: "hidden",
+                          boxShadow: `inset 0 0 4px ${withAlpha("#000000", 0.35)}`,
+                        }}
+                      >
+                        <div
+                          style={{
+                            width: `${countdownProgress * 100}%`,
+                            background: countdownFill,
+                            height: "100%",
+                            transition: "width 0.3s ease",
+                          }}
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## Summary
- add a reusable helper for mapping absolute timer remaining time to a 30-day countdown progress
- render the countdown bar on absolute timer cards to visualize remaining time against the 30-day window
- show the same countdown indicator in the overview list for absolute timers so the progress is visible wherever they appear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff709df4c832aa01377f1b725e310