### PR TITLE
Add TP/RP history logging with sparkline visualizations

### DIFF
--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,43 @@
+export type ResourceKind = "tp" | "rp";
+
+export interface ResourceHistoryPoint {
+  ts: number;
+  value: number;
+}
+
+export type ResourceHistoryEventType = "spend" | "manual" | "reset";
+
+export interface ResourceHistoryEvent {
+  id: string;
+  ts: number;
+  kind: ResourceKind;
+  type: ResourceHistoryEventType;
+  value: number;
+  delta?: number;
+  note?: string;
+}
+
+export interface ResourceHistorySnapshot {
+  points: ResourceHistoryPoint[];
+  events: ResourceHistoryEvent[];
+}
+
+export interface ResourceHistoryState {
+  tp: ResourceHistorySnapshot;
+  rp: ResourceHistorySnapshot;
+}
+
+export interface ResourceHistoryEventInput {
+  type: ResourceHistoryEventType;
+  delta?: number;
+  note?: string;
+  force?: boolean;
+}
+
+export function createEmptyHistorySnapshot(): ResourceHistorySnapshot {
+  return { points: [], events: [] };
+}
+
+export function createEmptyHistoryState(): ResourceHistoryState {
+  return { tp: createEmptyHistorySnapshot(), rp: createEmptyHistorySnapshot() };
+}


### PR DESCRIPTION
## Summary
- add persistent TP/RP history models for resource samples and annotated events
- record spends, manual adjustments, and daily reset markers while sampling regen over time
- render sparkline charts with recent event details in the main cards and overlay views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff861fce8832aa57e73ec9178a9ef