### PR TITLE
Fix missing closing brace in describeHistoryEvent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -416,6 +416,7 @@ function describeHistoryEvent(
   if (delta > 0) return `Added ${Math.round(delta)} ${resourceLabel} → ${after} • ${time}`;
   if (delta < 0) return `Removed ${Math.round(Math.abs(delta))} ${resourceLabel} → ${after} • ${time}`;
   return `Adjusted ${resourceLabel} → ${after} • ${time}`;
+}
 
 function absTimerCountdownProgress(status: AbsTimerStatus | undefined, remainingMs: number) {
   if (status === "completed" || status === "expired") return 0;


### PR DESCRIPTION
## Summary
- close the describeHistoryEvent helper function with a trailing brace so subsequent exports remain at top level

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cffd603978832abc275da2ded20c6f