### PR TITLE
Remove unused timezone offset memo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3217,7 +3217,6 @@ export default function UmaResourceTracker() {
     () => nextDailyResetTS(new Date(), activeTimeZone),
     [tick, activeTimeZone]
   );
-  const tzOffset = useMemo(() => getTZOffsetDesignator(activeTimeZone), [activeTimeZone]);
 
   useEffect(() => {
     const ts = now();


### PR DESCRIPTION
## Summary
- remove the unused timezone offset memoization to satisfy the TypeScript compiler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0031f0884832a9d1781fec1b110cc