### PR TITLE
Fix overlay CSS leaking to main app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@types/electron": "^1.4.38",
         "@types/node": "^24.5.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.2",
@@ -1149,6 +1150,16 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/electron": {
+      "version": "1.4.38",
+      "resolved": "https://registry.npmjs.org/@types/electron/-/electron-1.4.38.tgz",
+      "integrity": "sha512-Cu6laqBamT6VSPi0LLlF9vE9Os8EbTaI/5eJSsd7CPoLUG3Znjh04u9TxMhQYPF1wGFM14Z8TFQ2914JZ+rGLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/electron": "^1.4.38",
     "@types/node": "^24.5.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.2",

--- a/src/routes/Overlay.tsx
+++ b/src/routes/Overlay.tsx
@@ -180,6 +180,15 @@ function useQueryParams() {
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 function Overlay() {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const { classList } = document.body;
+    classList.add("overlay-mode");
+    return () => {
+      classList.remove("overlay-mode");
+    };
+  }, []);
+
   const snapshot = useOverlaySnapshot();
   const overlayState = useOverlayRendererState();
   const params = useQueryParams();

--- a/src/styles/overlay.css
+++ b/src/styles/overlay.css
@@ -2,8 +2,7 @@
   color-scheme: dark;
 }
 
-html,
-body {
+body.overlay-mode {
   margin: 0;
   padding: 0;
   background: transparent;


### PR DESCRIPTION
## Summary
- scope overlay stylesheet to a body overlay-mode class so the main web app can scroll again
- add an effect in the overlay route to toggle the overlay-mode class while it is mounted
- install @types/electron so the Electron TypeScript lint task can run cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d222a6d2c4832aabc382a66736065d